### PR TITLE
Removed unsupported option '-n' from usage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Actions:
     validate    validate template
 
 Options:
-    -n, --dry-run       only shows command-lines
     -s, --stack-name    specify stack name
     -c, --capabilities  specify capabilities
     -e, --environment   specify environment
     -p, --profile       specify AWS_PROFILE
+
+    --dry-run           only shows command-lines
 ```
 
 ## Installation

--- a/cfstacker/cfstacker.py
+++ b/cfstacker/cfstacker.py
@@ -123,11 +123,12 @@ Actions:
     validate    validate template
 
 Options:
-    -n, --dry-run       only shows command-lines
     -s, --stack-name    specify stack name
     -c, --capabilities  specify capabilities
     -e, --environment   specify environment
     -p, --profile       specify AWS_PROFILE
+
+    --dry-run           only shows command-lines
 """.strip()
 
 


### PR DESCRIPTION
Removed unsupported option `-n` (short-hand of `--dry-run`) from usage message.
(If specified, exited after display usage.)